### PR TITLE
Resolve "Redirect users back to where they were before the authentication process started "

### DIFF
--- a/src/runtime/components/Auth0Login.vue
+++ b/src/runtime/components/Auth0Login.vue
@@ -11,19 +11,56 @@ const loginWithAuth0 = () => {
   window.location.href = "/auth/auth0";
 };
 
-// Check for stored redirect URI on component mount
+// Handle redirect logic on component mount
 onMounted(() => {
-  console.log("🔍 Auth0Login: Component mounted, checking for redirect URI");
-  const redirectUri = sessionStorage.getItem("auth0_redirect_uri");
-  console.log("🔍 Auth0Login: Found redirect URI:", redirectUri);
-  if (redirectUri) {
-    console.log("🔍 Auth0Login: Redirecting to:", redirectUri);
-    // Clear the stored URI
-    sessionStorage.removeItem("auth0_redirect_uri");
-    // Redirect to the original destination
-    window.location.href = redirectUri;
+  console.log(
+    "🔍 Auth0Login: Component mounted, checking URL for redirect logic",
+  );
+
+  const currentUrl = window.location.href;
+  const currentPath = window.location.pathname;
+
+  console.log("🔍 Auth0Login: Current URL:", currentUrl);
+  console.log("🔍 Auth0Login: Current path:", currentPath);
+
+  // Skip if we're already on login page
+  if (currentPath === "/login") {
+    console.log(
+      "🔍 Auth0Login: Already on login page, checking for stored redirect",
+    );
+    const storedRedirect = sessionStorage.getItem("auth0_redirect_uri");
+    if (storedRedirect) {
+      console.log(
+        "🔍 Auth0Login: Found stored redirect, redirecting to:",
+        storedRedirect,
+      );
+      sessionStorage.removeItem("auth0_redirect_uri");
+      window.location.href = storedRedirect;
+    } else {
+      console.log("🔍 Auth0Login: No stored redirect found, staying on login");
+    }
+    return;
+  }
+
+  // Check if we're on a guardianconnector.net domain
+  if (currentUrl.includes("guardianconnector.net")) {
+    console.log(
+      "🔍 Auth0Login: On guardianconnector.net, storing current URL for redirect",
+    );
+    sessionStorage.setItem("auth0_redirect_uri", currentUrl);
   } else {
-    console.log("🔍 Auth0Login: No redirect URI found, staying on login page");
+    console.log(
+      "🔍 Auth0Login: Not on guardianconnector.net, clearing any stored redirect",
+    );
+    const storedRedirect = sessionStorage.getItem("auth0_redirect_uri");
+    if (storedRedirect) {
+      console.log(
+        "🔍 Auth0Login: Found stored redirect, redirecting to:",
+        storedRedirect,
+      );
+      sessionStorage.removeItem("auth0_redirect_uri");
+      window.location.href = storedRedirect;
+    }
   }
 });
 </script>

--- a/src/runtime/components/Auth0Login.vue
+++ b/src/runtime/components/Auth0Login.vue
@@ -13,12 +13,17 @@ const loginWithAuth0 = () => {
 
 // Check for stored redirect URI on component mount
 onMounted(() => {
+  console.log("🔍 Auth0Login: Component mounted, checking for redirect URI");
   const redirectUri = sessionStorage.getItem("auth0_redirect_uri");
+  console.log("🔍 Auth0Login: Found redirect URI:", redirectUri);
   if (redirectUri) {
+    console.log("🔍 Auth0Login: Redirecting to:", redirectUri);
     // Clear the stored URI
     sessionStorage.removeItem("auth0_redirect_uri");
     // Redirect to the original destination
     window.location.href = redirectUri;
+  } else {
+    console.log("🔍 Auth0Login: No redirect URI found, staying on login page");
   }
 });
 </script>

--- a/src/runtime/components/Auth0Login.vue
+++ b/src/runtime/components/Auth0Login.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { onMounted } from "vue";
+
 interface Props {
   errorMessage: string;
 }
@@ -8,6 +10,17 @@ const props = defineProps<Props>();
 const loginWithAuth0 = () => {
   window.location.href = "/auth/auth0";
 };
+
+// Check for stored redirect URI on component mount
+onMounted(() => {
+  const redirectUri = sessionStorage.getItem("auth0_redirect_uri");
+  if (redirectUri) {
+    // Clear the stored URI
+    sessionStorage.removeItem("auth0_redirect_uri");
+    // Redirect to the original destination
+    window.location.href = redirectUri;
+  }
+});
 </script>
 
 <template>

--- a/src/runtime/components/LanguagePicker.vue
+++ b/src/runtime/components/LanguagePicker.vue
@@ -12,7 +12,7 @@ interface Locale {
 
 // Populate available locales from i18n plugin
 const availableLocales = computed(() => locales.value);
-
+console.log("🔍 LanguagePicker: availableLocales:", availableLocales.value);
 const currentLocaleName = computed(() => {
   const currentLocale = locales.value.find(
     (lang: Locale) => lang.code === locale.value,

--- a/src/runtime/middleware/oauth.global.ts
+++ b/src/runtime/middleware/oauth.global.ts
@@ -13,6 +13,12 @@ export default defineNuxtRouteMiddleware(async (to) => {
   } = useRuntimeConfig();
 
   if (authStrategy === "auth0" && !loggedIn.value && to.path !== "/login") {
+    // Only store redirect URI on client side
+    if (import.meta.client) {
+      const redirectUri = window.location.href;
+      sessionStorage.setItem("auth0_redirect_uri", redirectUri);
+    }
+    // Redirect to login
     return navigateTo("/login");
   }
 });

--- a/src/runtime/middleware/oauth.global.ts
+++ b/src/runtime/middleware/oauth.global.ts
@@ -11,16 +11,8 @@ export default defineNuxtRouteMiddleware(async (to) => {
   const {
     public: { authStrategy },
   } = useRuntimeConfig();
-  console.log("🔍 Middleware: authStrategy:", authStrategy);
-  console.log("🔍 Middleware: loggedIn:", loggedIn.value);
-  console.log("🔍 Middleware: to.path:", to.path);
+
   if (authStrategy === "auth0" && !loggedIn.value && to.path !== "/login") {
-    // Only store redirect URI on client side
-    if (import.meta.client) {
-      const redirectUri = window.location.href;
-      sessionStorage.setItem("auth0_redirect_uri", redirectUri);
-    }
-    // Redirect to login
     return navigateTo("/login");
   }
 });

--- a/src/runtime/middleware/oauth.global.ts
+++ b/src/runtime/middleware/oauth.global.ts
@@ -11,7 +11,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
   const {
     public: { authStrategy },
   } = useRuntimeConfig();
-
+  console.log("🔍 Middleware: authStrategy:", authStrategy);
+  console.log("🔍 Middleware: loggedIn:", loggedIn.value);
+  console.log("🔍 Middleware: to.path:", to.path);
   if (authStrategy === "auth0" && !loggedIn.value && to.path !== "/login") {
     // Only store redirect URI on client side
     if (import.meta.client) {

--- a/test/unit/Auth0Login.spec.ts
+++ b/test/unit/Auth0Login.spec.ts
@@ -65,5 +65,93 @@ describe("Auth0Login", () => {
     await wrapper.find("button").trigger("click");
 
     expect(window.location.href).toBe("/auth/auth0");
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("redirects to stored URI on mount if present", async () => {
+    const originalLocation = window.location;
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { href: "" } as Location,
+    });
+
+    // Mock sessionStorage
+    const mockSessionStorage = {
+      getItem: vi.fn().mockReturnValue("/config"),
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+      clear: vi.fn(),
+    };
+    Object.defineProperty(window, "sessionStorage", {
+      value: mockSessionStorage,
+      writable: true,
+    });
+
+    const wrapper = mountAuth0Login();
+
+    // Wait for onMounted to execute
+    await wrapper.vm.$nextTick();
+
+    expect(mockSessionStorage.getItem).toHaveBeenCalledWith(
+      "auth0_redirect_uri",
+    );
+    expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(
+      "auth0_redirect_uri",
+    );
+    expect(window.location.href).toBe("/config");
+
+    // Restore original values
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("does not redirect if no stored URI", async () => {
+    const originalLocation = window.location;
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { href: "" } as Location,
+    });
+
+    // Mock sessionStorage
+    const mockSessionStorage = {
+      getItem: vi.fn().mockReturnValue(null),
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+      clear: vi.fn(),
+    };
+    Object.defineProperty(window, "sessionStorage", {
+      value: mockSessionStorage,
+      writable: true,
+    });
+
+    const wrapper = mountAuth0Login();
+
+    // Wait for onMounted to execute
+    await wrapper.vm.$nextTick();
+
+    expect(mockSessionStorage.getItem).toHaveBeenCalledWith(
+      "auth0_redirect_uri",
+    );
+    expect(mockSessionStorage.removeItem).not.toHaveBeenCalled();
+    expect(window.location.href).toBe(""); // Should not change
+
+    // Restore original values
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
   });
 });

--- a/test/unit/Auth0Login.spec.ts
+++ b/test/unit/Auth0Login.spec.ts
@@ -24,7 +24,9 @@ const i18n = createI18n({
 });
 
 // Helper function to mount the Auth0Login component
-const mountAuth0Login = (props = {}) => {
+const mountAuth0Login = (
+  props: { errorMessage: string } = { errorMessage: "" },
+) => {
   return mount(Auth0Login, {
     global: {
       plugins: [i18n],
@@ -63,7 +65,5 @@ describe("Auth0Login", () => {
     await wrapper.find("button").trigger("click");
 
     expect(window.location.href).toBe("/auth/auth0");
-
-    window.location = originalLocation;
   });
 });


### PR DESCRIPTION
## Goal
Implement redirect after login functionality so users are returned to their original destination after authentication. Closes ConservationMetrics/gc-explorer#155 

## Screenshots
N/A 

## What I changed
- **Middleware (`oauth.global.ts`)**: Added client-side storage of current URL in sessionStorage before redirecting to login
- **Component (`Auth0Login.vue`)**: Added automatic redirect to stored URI on component mount after successful authentication
- **Tests**: Added unit tests for redirect functionality and updated existing tests

## What I'm not doing here
- No server-side redirect handling - using client-side sessionStorage for simplicity

Note: Consuming applications should ensure the Auth0Login component is always rendered (not conditionally with v-if="loggedIn === false") so the redirect logic can execute after successful authentication. I noticed this is something we do in `gc-explorer`. 