### PR TITLE
Rename package to `gc-shared-nuxt-resources`, and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Unlike many Nuxt modules, this repository does not use a `playground/` directory
 For development purposes, utilize a symlink to this module in a Nuxt application to use your local code in runtime:
 
 ### 1. Prepare the module
+
 Inside the `gc-shared-nuxt-resources` directory:
 
 ```bash
@@ -54,7 +55,8 @@ pnpm link gc-shared-nuxt-resources
 
 ``bash
 ls -l node_modules/gc-shared-nuxt-resources
-```
+
+````
 
 You should see a symlink pointing to your local module directory.
 
@@ -66,33 +68,33 @@ You should see a symlink pointing to your local module directory.
 
 <details>
   <summary>Local development</summary>
-  
+
   ```bash
   # Install dependencies
   pnpm install
-  
+
   # Generate type stubs
   pnpm run dev:prepare
-  
+
   # Develop with the playground
   pnpm run dev
-  
+
   # Build the playground
   pnpm run dev:build
-  
+
   # Create a (p)npm symlink
   pnpm run link
-  
+
   # Run Prettier
   pnpm run lint
-  
+
   # Run Vitest
   pnpm run test
   pnpm run test:watch
-  
+
   # Release new version
   pnpm run release
-  ```
+````
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ls -l node_modules/gc-shared-nuxt-resources
 
 You should see a symlink pointing to your local module directory.
 
-> ![NOTE]
+> [!CAUTION]
 >
 > 💡 Avoid running `pnpm install` in your Nuxt app again afterward, or it may override the symlink with the npm version unless the versions match exactly.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GuardianConnector Shared Resources Library
+# GuardianConnector Shared Nuxt Resources Library
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
@@ -14,10 +14,10 @@ Shared components (components, pages, assets, middleware and more) for GuardianC
 Install the module to your Nuxt application with one command:
 
 ```bash
-npx nuxi module add gc-shared-resources
+npx nuxi module add gc-shared-nuxt-resources
 ```
 
-That's it! You can now use GuardianConnector Shared Resources Library in your Nuxt app ✨
+That's it! You can now use GuardianConnector Shared Nuxt Resources Library in your Nuxt app ✨
 
 ## How to use this module
 
@@ -25,8 +25,42 @@ Unlike many Nuxt modules, this repository does not use a `playground/` directory
 
 For development purposes, utilize a symlink to this module in a Nuxt application to use your local code in runtime:
 
-1. Generate type stubs by running `pnpm run dev:prepare`
-2. In your Nuxt application, run `pnpm link ../gc-shared-components` (assuming your module and Nuxt application are in the same root directory, if not adapt the path)
+### 1. Prepare the module
+Inside the `gc-shared-nuxt-resources` directory:
+
+```bash
+pnpm run dev:prepare
+```
+
+This generates type stubs and prepares the build artifacts.
+
+### 2. Link the module globally
+
+Still in `gc-shared-nuxt-resources`, run:
+
+```bash
+pnpm link --global
+```
+
+### 3. Link it in the Nuxt app
+
+Now go to your Nuxt app (e.g., `gc-explorer`) and link the global module:
+
+```bash
+pnpm link gc-shared-nuxt-resources
+```
+
+### 4. Verify the Link
+
+``bash
+ls -l node_modules/gc-shared-nuxt-resources
+```
+
+You should see a symlink pointing to your local module directory.
+
+> ![NOTE]
+>
+> 💡 Avoid running `pnpm install` in your Nuxt app again afterward, or it may override the symlink with the npm version unless the versions match exactly.
 
 ## Contribution
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gc-shared-resources",
+  "name": "gc-shared-nuxt-resources",
   "version": "1.1.8",
   "description": "Shared resources for Guardian Connector Nuxt.js applications",
   "type": "module",

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,7 +16,7 @@ export interface ModuleOptions {
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
-    name: "gc-shared-resources",
+    name: "gc-shared-nuxt-resources",
     configKey: "gcSharedResources",
   },
 


### PR DESCRIPTION
I think it is confusing that the repo is called `gc-shared-nuxt-resources` but the NPM package is called `gc-shared-resources`. I prefer the former name as it is more specific. This PR aims to have us be consistent in the naming convention, and fix the confusion once and for all.

I've also improved the README to better describe how to set up the symlink with this repo for local development in `gc-explorer` and other Nuxt repos.

> [!IMPORTANT]
>
> This change means that we will need to update `gc-explorer` to use the new package name.